### PR TITLE
fix emitting collectionChange after remove control

### DIFF
--- a/lib/src/models/models.dart
+++ b/lib/src/models/models.dart
@@ -1569,6 +1569,8 @@ class FormGroup extends FormControlCollection<Map<String, Object?>> {
 
     _controls.removeWhere((key, value) => key == name);
     updateValueAndValidity(updateParent: updateParent, emitEvent: emitEvent);
+
+    emitsCollectionChanged(_controls.values.toList());
   }
 
   @override


### PR DESCRIPTION
add emitsCollectionChanged after remove control from FormGroup

## Connection with issue(s)

<!-- If this pull request close some issue, use this reference to close it automatically -->
Close #???

<!-- Optional: other issues or pull requests related to this, but merging should not close it -->
Connected to #???

## Solution description

## Screenshots or Videos

<!-- Optional: to clearly demonstrate the feature or fix to help with testing and reviews -->

## To Do

- [ ] Check the original issue to confirm it is fully satisfied
- [ ] Add solution description to help guide reviewers
- [ ] Add unit test to verify new or fixed behaviour
- [ ] If apply, add documentation to code properties and package readme